### PR TITLE
Adds suffix support for compile css in prop-map

### DIFF
--- a/scss/pack/mixins/_prop-map.scss
+++ b/scss/pack/mixins/_prop-map.scss
@@ -1,6 +1,6 @@
 // Mixins :: Prop Map
 
-@mixin prop-map($map: false, $properties: false, $class: false) {
+@mixin prop-map($map: false, $properties: false, $suffix: false) {
   @if $map {
     // Set global maps
     $_seed-props-map: () !global;
@@ -8,6 +8,9 @@
     @each $key, $value in $map {
       // Set the class name
       $class: $key;
+      @if $suffix {
+        $class: $class + $suffix;
+      }
       // Add the properties
       @if $properties {
         @each $prop in $properties {


### PR DESCRIPTION
This was added to support breakpoint loops in [seed-breakpoints](https://github.com/helpscout/seed-breakpoints)

Usage:

``` sass
// scss
.col- {
  @include prop-map($obj, (width), --at-sm) {
    width: prop(width);
  }
}

// css
.col-1--at-sm {
  width: 10px;
}
```
