### PR TITLE
Adds hyphen before class name

### DIFF
--- a/scss/pack/seed-props/mixins/_prop-map.scss
+++ b/scss/pack/seed-props/mixins/_prop-map.scss
@@ -39,7 +39,7 @@
         }
       }
       // Return @content
-      &#{$class} {
+      &-#{$class} {
         @content;
       }
     }


### PR DESCRIPTION
A simple, but important change. This automatically adds the `-`before the mapped class name.

_Before_

```
.class- {
  @include prop-map($map, (size) {
    ...
  }
}
```

_After_

```
.class {
  @include prop-map($map, (size) {
    ...
  }
}
```
